### PR TITLE
Fix compilation in standards-compliant mode

### DIFF
--- a/C700defines.h
+++ b/C700defines.h
@@ -180,7 +180,7 @@ typedef struct BRRData {
     int samples() const { return (size/9)*16; }
 } BRRData;
 
-typedef struct {
+struct InstParams {
 public:
     char        pgname[PROGRAMNAME_MAX_LEN];
     int         ar,dr,sl,sr1,sr2;
@@ -240,7 +240,7 @@ public:
     }
 private:
     BRRData     brr;    
-} InstParams;
+};
 
 float ConvertToVSTValue( float value, float min, float max );
 float ConvertFromVSTValue( float value, float min, float max );

--- a/MidiDriverBase.h
+++ b/MidiDriverBase.h
@@ -91,7 +91,7 @@ public:
         INVALID_TYPE        = 0x00,
     };
     
-    typedef struct {
+    struct MIDIEvt {
         EvtType     type;
         uint8_t     ch;
         uint8_t     data1;
@@ -102,9 +102,9 @@ public:
         bool isLegato() const { return (data1&0x80)!=0 ? true:false; }
         void setAllocedVo(int vo) { ch = (ch & 0x0f) | ((vo & 0x0f) << 4); }
         int getAllocedVo() const { return (ch & 0xf0) >> 4; }
-    } MIDIEvt;
+    };
     
-    typedef struct {
+    struct ChannelStatus {
         int     prog;
         int     pitchBend;
         int     afterTouch;
@@ -121,7 +121,7 @@ public:
         bool    isSettingNRPN;
         int     rpn;
         int     nrpn;
-    } ChannelStatus;
+    };
     
     MidiDriverBase(int maxVoices=8);
     virtual ~MidiDriverBase();

--- a/commusb/ControlUSB.cpp
+++ b/commusb/ControlUSB.cpp
@@ -680,14 +680,14 @@ bool ControlUSB::openDevice(std::basic_string<TCHAR> devpath)
 		NULL);
 
 	if (hNewDev == INVALID_HANDLE_VALUE) {
-		goto bail;
+		return false;
 	}
 
 	HANDLE hNewWinUsb = NULL;
 	if (!WinUsb_Initialize(hNewDev, &hNewWinUsb)) {
 		//DWORD err = GetLastError();
 		CloseHandle(hNewDev);
-		goto bail;
+		return false;
 	}
 
 	// エンドポイント情報取得
@@ -695,7 +695,7 @@ bool ControlUSB::openDevice(std::basic_string<TCHAR> devpath)
 	if (!WinUsb_QueryInterfaceSettings(hNewWinUsb, 0, &desc)) {
 		WinUsb_Free(hNewWinUsb);
 		CloseHandle(hNewDev);
-		goto bail;
+		return false;
 	}
 
 	for (int i = 0; i<desc.bNumEndpoints; i++) {
@@ -733,9 +733,6 @@ bool ControlUSB::openDevice(std::basic_string<TCHAR> devpath)
 	}
 
 	return true;
-
-bail:
-	return false;
 }
 void ControlUSB::EndPortWait()
 {

--- a/vstgui/ctooltipsupport.cpp
+++ b/vstgui/ctooltipsupport.cpp
@@ -409,7 +409,7 @@ void* InitTooltip (CFrame* frame)
     ti.hwnd   = (HWND)frame->getSystemWindow ();
     ti.uId    = (UINT)0;
     ti.hinst  = GetInstance ();
-    ti.lpszText  = TEXT("This is a tooltip");
+    ti.lpszText  = const_cast<LPSTR>(TEXT("This is a tooltip"));
 	ti.rect.left = ti.rect.top = ti.rect.bottom = ti.rect.right = 0;
 
 	// Add the tool to the control


### PR DESCRIPTION
When I build in VS2019 (v142) with `/permissive-` enabled (automatically enabled by `/std:c++latest`), parts of the code no longer compile because they are not valid C++, but MSVC only accepts them to preserve backwards compatibility.

This code compiles in VS2019, but I don't know if it compiles in VS2015 or VS2005.